### PR TITLE
Validación de única solicitud de reembolso activa

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -398,7 +398,7 @@ class RefundRequest(models.Model):
         return f"Refund request for {self.ticket.ticket_code} by {self.user.username}"
     
     @classmethod
-    def validate(cls, reason, ticket, existing_instance=None):
+    def validate(cls, user, reason, ticket, existing_instance=None):
         errors = {}
 
         if not reason or len(reason.strip().split()) < 1:
@@ -412,13 +412,16 @@ class RefundRequest(models.Model):
             elif ticket.used:
                 errors["ticket"] = "El ticket ya ha sido usado y no puede ser reembolsado."
             elif ticket.event.scheduled_at + datetime.timedelta(days=30) < timezone.now():
-                errors["ticket"] = "Han pasado más de 30 días desde el evento. No es posible solicitar reembolso."
-        
+                errors["ticket"] = "Han pasado más de 30 días desde el evento. No es posible solicitar reembolso."                
+        # Validar que el usuario no pueda ingresar una solicitud de reembolso si ya tiene otra activa. #
+        if RefundRequest.objects.filter(user=user, status='pendiente').exclude(pk=getattr(existing_instance, 'pk', None)).exists():
+            errors["general"] = "Ya tenés una solicitud de reembolso pendiente."
+
         return errors
     
     @classmethod
     def new(cls, user, status, approval_date, ticket, reason):
-        errors = cls.validate(reason, ticket)
+        errors = cls.validate(user, reason, ticket)
 
         if errors:
             return None, errors
@@ -434,7 +437,7 @@ class RefundRequest(models.Model):
         return refund, None
     
     def update(self, status=None, approval_date=None, reason=None):
-        errors = self.validate(reason or self.reason, self.ticket, existing_instance=self)
+        errors = self.validate(self.user, reason or self.reason, self.ticket, existing_instance=self)
 
         if errors:
             return False, errors

--- a/app/test/test_e2e/test_refund_request.py
+++ b/app/test/test_e2e/test_refund_request.py
@@ -1,0 +1,67 @@
+import datetime
+import re
+from django.utils import timezone
+from playwright.sync_api import expect
+from app.models import Event, Ticket, User
+from app.test.test_e2e.base import BaseE2ETest
+
+
+class RefundRequestBaseTest(BaseE2ETest):
+    def setUp(self):
+        super().setUp()
+
+        # Creo usuario organizador y usuario regular
+        self.organizer = User.objects.create_user(
+            username="organizador",
+            email="org@example.com",
+            password="password123",
+            is_organizer=True,
+        )
+        self.user = User.objects.create_user(
+            username="usuario",
+            email="user@example.com",
+            password="123",  # Confirmado por vos
+            is_organizer=False,
+        )
+
+        # Creo evento
+        event_date = timezone.make_aware(datetime.datetime(2025, 6, 10, 20, 0))
+        self.event = Event.objects.create(
+            title="Evento E2E",
+            description="Evento para prueba E2E",
+            scheduled_at=event_date,
+            organizer=self.organizer,
+        )
+
+        # Creo dos tickets para el usuario
+        self.ticket1 = Ticket.objects.create(
+            ticket_code="REFUND1", user=self.user, event=self.event, used=False
+        )
+        self.ticket2 = Ticket.objects.create(
+            ticket_code="REFUND2", user=self.user, event=self.event, used=False
+        )
+
+
+class RefundRequestE2ETest(RefundRequestBaseTest):
+    def test_user_cannot_create_duplicate_pending_refund(self):
+        # Inicio sesión como usuario
+        self.login_user("usuario", "123")
+
+        # Relleno y envío primer formulario de reembolso
+        self.page.goto(f"{self.live_server_url}/refund-request/create/?ticket_code={self.ticket1.ticket_code}")
+        campo = self.page.locator("textarea[name='reason']")
+        expect(campo).to_be_visible()
+        campo.fill("Quiero reembolso del primer ticket")
+        self.page.get_by_role("button", name="Crear Solicitud").click()
+
+        # Relleno y envío segundo formulario de reembolso
+        self.page.goto(f"{self.live_server_url}/refund-request/create/?ticket_code={self.ticket2.ticket_code}")
+        campo2 = self.page.locator("textarea[name='reason']")
+        expect(campo2).to_be_visible()
+        campo2.fill("Quiero reembolso del segundo ticket")
+        self.page.get_by_role("button", name="Crear Solicitud").click()
+
+        # Verifico que se muestre el mensaje de error
+        error_message = self.page.locator("text=Ya tenés una solicitud de reembolso pendiente.")
+        expect(error_message).to_be_visible()
+

--- a/app/test/test_integration/test_refund_request.py
+++ b/app/test/test_integration/test_refund_request.py
@@ -1,0 +1,30 @@
+from django.test import TestCase, Client
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from django.utils import timezone
+from app.models import Event, Ticket, RefundRequest
+
+User = get_user_model()
+
+class RefundRequestIntegrationTest(TestCase):
+    def setUp(self):
+        self.client = Client()
+        self.user = User.objects.create_user(username="testuser", password="pass")
+        self.client.login(username="testuser", password="pass")
+        organizer = User.objects.create_user(username="org", password="pass")
+        self.event = Event.objects.create(
+            title="Test Event",
+            description="Desc",
+            scheduled_at=timezone.now(),
+            organizer=organizer
+        )
+        self.ticket1 = Ticket.objects.create(ticket_code="TICKET1", user=self.user, event=self.event, used=False)
+        self.ticket2 = Ticket.objects.create(ticket_code="TICKET2", user=self.user, event=self.event, used=False)
+        RefundRequest.objects.create(user=self.user, status='pendiente', ticket=self.ticket1, reason="Primera solicitud")
+
+    def test_user_cannot_create_duplicate_pending_refund(self):
+        response = self.client.post(reverse('refund_request_form'), {
+            "ticket_code": self.ticket2.ticket_code,
+            "reason": "Intento duplicado"
+        }, follow=True)
+        self.assertContains(response, "Ya tenés una solicitud de reembolso pendiente.")

--- a/app/test/test_unit/test_refund_request.py
+++ b/app/test/test_unit/test_refund_request.py
@@ -1,0 +1,32 @@
+from django.utils import timezone
+from django.test import TestCase
+from django.contrib.auth import get_user_model
+from app.models import RefundRequest, Ticket, Event
+
+User=get_user_model()
+
+class RefundRequestUnitTest(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username="testuser", password="pass")
+        organizer = User.objects.create_user(username="org", password="pass")
+        self.event = Event.objects.create(
+            title="Test Event",
+            description="Desc",
+            scheduled_at=timezone.now(),
+            organizer=organizer
+        )
+        self.event = Event.objects.get(pk=1)
+        self.ticket1 = Ticket.objects.create(ticket_code="ABC123", user=self.user, event=self.event, used=False)
+        self.ticket2 = Ticket.objects.create(ticket_code="DEF456", user=self.user, event=self.event, used=False)
+
+    def test_user_cannot_have_multiple_pending_refunds(self):
+        RefundRequest.objects.create(user=self.user, status='pendiente', ticket=self.ticket1, reason="Primera")
+
+        refund, errors = RefundRequest.new(self.user, "pendiente", None, self.ticket2, "Segunda")
+
+        self.assertIsNone(refund)
+        if errors:
+            self.assertIn("general", errors)
+            self.assertEqual(errors["general"], "Ya tenés una solicitud de reembolso pendiente.")
+        else:
+            self.fail("Se esperaba un error de validación, pero no se devolvieron errores.")


### PR DESCRIPTION
Inciso 12. Validar que el usuario no pueda ingresar una solicitud de reembolso si ya tiene otra activa.

- Método de validación en RefundRequest para detectar solicitudes pendientes.
- Ajustes en la vista refund_request_form para aplicar la validación.
- Mensaje de error mostrado en el template cuando la condición se cumple.
- Test unitario, de integración y e2e.