### PR TITLE
Ocultar eventos pasados del dashboard

### DIFF
--- a/app/test/test_e2e/test_events_filter.py
+++ b/app/test/test_e2e/test_events_filter.py
@@ -1,0 +1,16 @@
+from playwright.sync_api import sync_playwright
+import pytest
+
+@pytest.mark.e2e
+def test_event_list_hides_past_events():
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        page = browser.new_page()
+        page.goto("http://localhost:8000/accounts/login/")
+        page.fill("input[name='username']", "test")
+        page.fill("input[name='password']", "1234")
+        page.click("text=Ingresar")
+        page.goto("http://localhost:8000/events/")
+        assert "Evento Futuro" in page.content()
+        assert "Evento Pasado" not in page.content()
+        browser.close()

--- a/app/test/test_integration/test_event_filter.py
+++ b/app/test/test_integration/test_event_filter.py
@@ -1,0 +1,40 @@
+from django.test import Client, TestCase
+from django.urls import reverse
+from django.utils import timezone
+from app.models import Event, User, Venue, Category
+from datetime import timedelta
+
+class EventIntegrationTest(TestCase):
+    def setUp(self):
+        self.client = Client()
+        self.user = User.objects.create_user(username="test", password="1234")
+        self.venue = Venue.objects.create(name="Test", address="Dir", city="C", capacity=100)
+        self.category = Category.objects.create(name="Cat", description="Desc")
+
+        self.future_event = Event.objects.create(
+            title="Futuro",
+            description="Futuro",
+            scheduled_at=timezone.now() + timedelta(days=2),
+            organizer=self.user,
+            price_general=100,
+            price_vip=200,
+            venue=self.venue,
+            category=self.category,
+        )
+
+        self.past_event = Event.objects.create(
+            title="Pasado",
+            description="Pasado",
+            scheduled_at=timezone.now() - timedelta(days=2),
+            organizer=self.user,
+            price_general=100,
+            price_vip=200,
+            venue=self.venue,
+            category=self.category,
+        )
+
+    def test_event_list_view_filters_past_events(self):
+        self.client.login(username="test", password="1234")
+        response = self.client.get(reverse("events"))
+        self.assertContains(response, "Futuro")
+        self.assertNotContains(response, "Pasado")

--- a/app/test/test_unit/test_event_filter.py
+++ b/app/test/test_unit/test_event_filter.py
@@ -1,0 +1,39 @@
+from django.test import TestCase
+from django.utils import timezone
+from app.models import Event, User, Venue, Category
+from datetime import timedelta
+
+class EventFilterUnitTest(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username="user", password="1234")
+        self.venue = Venue.objects.create(name="Lugar", address="Dir", city="City", capacity=100)
+        self.category = Category.objects.create(name="Concierto", description="Musica")
+
+        # Evento futuro
+        Event.objects.create(
+            title="Evento Futuro",
+            description="Desc",
+            scheduled_at=timezone.now() + timedelta(days=1),
+            organizer=self.user,
+            price_general=100,
+            price_vip=200,
+            venue=self.venue,
+            category=self.category,
+        )
+
+        # Evento pasado
+        Event.objects.create(
+            title="Evento Pasado",
+            description="Desc",
+            scheduled_at=timezone.now() - timedelta(days=1),
+            organizer=self.user,
+            price_general=100,
+            price_vip=200,
+            venue=self.venue,
+            category=self.category,
+        )
+
+    def test_default_filter_excludes_past_events(self):
+        events = Event.objects.filter(scheduled_at__gte=timezone.now())
+        self.assertEqual(events.count(), 1)
+        self.assertEqual(events.first().title, "Evento Futuro")

--- a/app/views.py
+++ b/app/views.py
@@ -79,6 +79,9 @@ def events(request):
     venue_id = request.GET.get("venue")
     category_id = request.GET.get("category")
 
+    if not date and not venue_id and not category_id:
+        events = events.filter(scheduled_at__gte=timezone.now())
+
     if date:
         events = events.filter(scheduled_at__date=date)
     if venue_id:


### PR DESCRIPTION
### Cambios realizados:
- Filtro por defecto en la vista `events` para excluir eventos pasados
- Creación de tests unitario, integración y E2E asociados al filtrado de eventos pasados
Closes #6